### PR TITLE
Fixed best new tracks to now save without quotation marks

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,25 @@ function getBestNewAlbums() {
     });
 }
 
+// Sanitizes the track from pitchfork to remove extraneous quotations
+function sanitizeBestNewTracks(title) { 
+  if(title.length >= 2) { 
+    // Check for first quotation
+    let firstLetter = title[0];
+    let titleLength = (title).length;
+    let lastLetter = title[titleLength - 1];
+    if(firstLetter === "“") { 
+      // Check for last quotation
+      if(lastLetter === "”") { 
+        // Sanitize the title 
+        title = (title).slice(1);
+        title = (title).slice(0, (title).length - 1);
+      }
+    }
+  }
+  return title;
+}
+
 function getBestNewTracks() {
   return fetch(p4kUrl + '/best/')
     .then(response => response.text())
@@ -96,6 +115,7 @@ function getBestNewTracks() {
         track.thumbnail = el$('div.artwork>img').attr('src');
         track.artist = el$('ul.artist-list').text();
         track.title = el$('h2.title').html();
+        track.title = sanitizeBestNewTracks(track.title);
         track.reviewUrl = p4kUrl + el$('a').attr('href');
 
         return track;
@@ -131,5 +151,6 @@ function getBestNewReissues() {
 module.exports = {
   getBestNewAlbums,
   getBestNewTracks,
-  getBestNewReissues
+  getBestNewReissues,
+  sanitizeBestNewTracks
 };

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,30 @@ test('fetch best new tracks', t => {
     });
 });
 
+test('sanitizing title with quotations', t => {
+  // Test title with extraneous quotations
+  let title = "“Hello”";
+  let titleTest = p4k.sanitizeBestNewTracks(title);
+  if(titleTest === "Hello") { 
+    t.pass();
+  }
+  else {
+    t.fail();
+  }
+})
+
+test('sanitizing title without quotations', t => {
+  // Test title without extraneous quotations
+  let title = "Hello";
+  let titleTest = p4k.sanitizeBestNewTracks(title);
+  if(titleTest === "Hello") { 
+    t.pass();
+  }
+  else {
+    t.fail();
+  }
+})
+
 test('fetch best new reissues', t=> {
   return p4k.getBestNewReissues()
     .then((reissues) => {


### PR DESCRIPTION
I created a new function that sanitizes best new tracks from PitchFork and removes the extraneous quotation marks. This issue was mentioned in [Nuclear's main repo](https://github.com/nukeop/nuclear/issues/1203). I also added 2 unit tests for the function I wrote in test.js. I ran npm test and my changes passes all tests. Please let me know if there's anything else I can do!
